### PR TITLE
fold detection via sign(det(J)) and bordered matrix

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -191,3 +191,16 @@ IS.@scoped_enum(
   - ARC_FLOWS = 0: Report total flows corresponding to arcs.
   - BRANCH_FLOWS = 1: Report flows for individual branches.
  " FlowReporting
+
+# Bordered fold monitor (`stop_at_fold`, see `residual_condition_diagnostics.jl`).
+# The monitor is g = 1/(d − cᵀJ⁻¹b) = det(J)/det(M) for the bordered matrix
+# M = [J b; cᵀ d]; sign(g) tracks sign(det J) up to the constant sign(det M).
+const FOLD_BORDER_D = 0.0 # the (n+1, n+1) entry `d` of the bordering
+const FOLD_BORDER_SEED = 0x5eed_f01d # seed of the deterministic bordering vectors b, c
+const FOLD_MAX_BORDER_REPICKS = 3 # re-picks of (b, c) after a degenerate (pole) event
+# A sign flip of g is classified by bisecting the step that produced it
+# (`_bracket_fold_flip!`): |g| shrinks onto a zero (a genuine singularity of J, i.e. a
+# fold) and grows onto a pole (det M crossed zero — the bordering degenerated, not a
+# property of J). Bisections of that step; near a simple zero or pole |g| moves
+# geometrically as the bracket tightens, so enough steps separate the two.
+const FOLD_BRACKET_STEPS = 20

--- a/src/levenberg-marquardt.jl
+++ b/src/levenberg-marquardt.jl
@@ -205,6 +205,9 @@ function _run_power_flow_method(
             # One-iterate lag: update_damping_factor! evaluated J at the pre-step
             # iterate but residual.Rv is already post-step, so κ̂/λ_min describe the
             # linearization J while the reported ‖F‖∞ is after the step. Not realigned.
+            # That lag is also why no iterate is passed: bracketing an ambiguous fold
+            # flip would have to re-evaluate residual/J together, which cannot be
+            # restored to this deliberately mismatched pair.
             run_solver_diagnostics!(
                 diag_state, "LM iter $i", residual, J, time_step,
                 diag_cache, monitor, stop_at_fold) &&

--- a/src/power_flow_method.jl
+++ b/src/power_flow_method.jl
@@ -828,7 +828,7 @@ function _run_power_flow_method(time_step::Int,
             # one refactor feeds both the log line and the bail-out.
             run_solver_diagnostics!(
                 diag_state, "NR iter $i", residual, J, time_step,
-                linSolveCache, monitor, stop_at_fold) &&
+                linSolveCache, monitor, stop_at_fold, stateVector.x) &&
                 return false, i
         end
         converged = norm(residual.Rv, Inf) < tol
@@ -915,7 +915,7 @@ function _run_power_flow_method(time_step::Int,
             # residual.Rv are at the same iterate, so one refactor feeds both.
             run_solver_diagnostics!(
                 diag_state, "TR iter $i", residual, J, time_step,
-                linSolveCache, monitor, stop_at_fold) &&
+                linSolveCache, monitor, stop_at_fold, stateVector.x) &&
                 return false, i
         end
         converged = norm(residual.Rv, Inf) < tol

--- a/src/residual_condition_diagnostics.jl
+++ b/src/residual_condition_diagnostics.jl
@@ -174,21 +174,256 @@ end
 # Fold / voltage-collapse bail-out state and the shared per-iteration hook.
 # ---------------------------------------------------------------------------
 
-# UNSEEN = pre-first-observation. A non-finite/non-converged λ_min is deliberately
-# not a sign here; the bail decision treats it as a conservative abort.
-IS.@scoped_enum(EigvalSign, UNSEEN = 0, NEGATIVE = -1, POSITIVE = 1)
+# FIXME a bit over-engineered.
+"""Deterministic pseudo-random unit vector, filled by an LCG so the bordering — and
+therefore every logged monitor value — is reproducible across runs, platforms, and
+Julia versions (no `Random` dependency, whose streams are not version-stable)."""
+function _fill_border_vector!(v::Vector{Float64}, seed::UInt64)
+    s = seed * 0x9E3779B97F4A7C15 + 0x1
+    @inbounds for i in eachindex(v)
+        s = s * 0x5851F42D4C957F2D + 0x14057B7EF767814F
+        v[i] = 2.0 * ((s >> 11) * 2.0^-53) - 1.0   # uniform in [-1, 1)
+    end
+    v ./= norm(v)
+    return v
+end
+
+"""
+    BorderedFoldMonitor(n_state)
+
+Fold monitor tracking `sign(det J)` through a bordered system. For fixed vectors
+`b`, `c` and scalar `d`, border `J` as
+
+    M = [ J   b
+          cᵀ  d ]
+
+The Schur complement gives `det(M) = det(J) · (d − cᵀJ⁻¹b)`, so with
+
+    s = d − cᵀJ⁻¹b        g = 1/s = det(J) / det(M)
+
+`g` is smooth along the continuation and vanishes exactly when `J` is singular:
+`det M` is a fixed smooth function, nonzero near a simple fold for generic `b`, `c`,
+so `sign(g)` differs from `sign(det J)` only by the constant factor `sign(det M)`. Therefore
+**flips of `g` are flips of `det J`**: we can monitor which branch we're on via tracking `g`.
+
+Cost per iteration: one back-solve `J y = b` against the *existing* factorization
+plus a dot product.
+
+`g` can flip sign two ways:
+
+  - through **zero**: a genuine singularity of `J` — the fold;
+  - through a **pole**: `det M` crossed zero. The bordering degenerated and `g` says
+    nothing about `J`. The monitor re-picks `b`, `c` and restarts its sign tracking
+    (it cannot recompute over past iterates, which are gone), up to
+    `FOLD_MAX_BORDER_REPICKS` times before disabling itself.
+
+The two are told apart by bisecting the *step* that produced the flip
+(`_bracket_fold_flip!`): as the bracket tightens onto the event one determinant
+vanishes there while the other stays continuous and nonzero, so `|g|` shrinks
+geometrically onto a zero and grows onto a pole. Only that limiting *trend* is used.
+The magnitude of `|g|` carries no usable information on its own — `|g| =
+|det J|/|det M|`, and nothing pins `|det M|`, so a small `|g|` may mean a vanishing
+`det J` or merely a swollen `det M`.
+
+Bisection needs `residual` and `J` evaluated at the passed iterate: NR/TR supply one,
+LM does not (its `J` lags the residual by a step). Without it a flip cannot be
+classified at all and is read conservatively as a fold.
+"""
+mutable struct BorderedFoldMonitor
+    b::Vector{Float64}
+    c::Vector{Float64}
+    d::Float64
+    y::Vector{Float64}      # work buffer: holds J⁻¹b after `solve!`
+    attempt::Int            # bordering index; bumped on every re-pick
+    sign::Int8              # sign(g) last seen; 0 = nothing seen yet
+    prev_abs_g::Float64     # |g| at the previous iteration (NaN = none)
+    enabled::Bool           # false once the bordering has degenerated too often
+    prev_x::Vector{Float64} # previous iterate, the low end of a bracketed step
+    has_prev_x::Bool
+    x_work::Vector{Float64} # interpolated iterate used while bracketing
+end
+
+function BorderedFoldMonitor(n_state::Int)
+    mon = BorderedFoldMonitor(
+        Vector{Float64}(undef, n_state), Vector{Float64}(undef, n_state),
+        FOLD_BORDER_D, Vector{Float64}(undef, n_state),
+        0, Int8(0), NaN, true,
+        Vector{Float64}(undef, n_state), false, Vector{Float64}(undef, n_state),
+    )
+    _repick_bordering!(mon)
+    return mon
+end
+
+"""Draw a fresh bordering `(b, c)` and reset the sign/magnitude history: after a
+re-pick `sign(det M)` is a different constant, so old signs are not comparable."""
+function _repick_bordering!(mon::BorderedFoldMonitor)
+    mon.attempt += 1
+    seed = FOLD_BORDER_SEED * UInt64(mon.attempt)
+    _fill_border_vector!(mon.b, seed)
+    _fill_border_vector!(mon.c, seed + 0x9E37)
+    mon.sign = Int8(0)
+    mon.prev_abs_g = NaN
+    return mon
+end
+
+"""`g = 1/(d − cᵀJ⁻¹b)` at the current iterate, via one back-solve against `cache`'s
+existing factorization. Returns `Inf` when the bordering is exactly degenerate
+(`s == 0`) and `NaN` if the back-solve produced a non-finite `s`."""
+function _fold_monitor_value!(mon::BorderedFoldMonitor, cache::PFLinearSolverCache)
+    copyto!(mon.y, mon.b)
+    solve!(cache, mon.y)
+    s = mon.d - dot(mon.c, mon.y)
+    isfinite(s) || return NaN
+    return inv(s)   # ±Inf when s == 0: a pole, handled as a degenerate bordering
+end
+
+"""Update the monitor with this iteration's `g` and decide the bail-out. Returns
+`true` to abort the search. A sign flip through zero (or an indeterminate `g`) is a
+fold; a flip through a pole is a degenerate bordering, which re-picks `(b, c)` and
+continues. An ambiguous flip is resolved by `bracket` (see
+[`_bracket_fold_flip!`](@ref)) when the caller supplies one. With `bail = false` the
+same classification is logged but never aborts."""
+function _decide_det_sign_switch!(
+    mon::BorderedFoldMonitor,
+    label::AbstractString,
+    g::Float64,
+    bail::Bool,
+    bracket::Union{Function, Nothing} = nothing,
+)::Bool
+    mon.enabled || return false
+
+    if isnan(g)
+        @warn "$label: fold monitor g = det(J)/det(M) indeterminate (non-finite " *
+              "back-solve); read as a fold$(bail ? ", aborting." : ".")"
+        return bail
+    end
+
+    abs_g = abs(g)
+    current = Int8(sign(g))
+    prev, prev_abs = mon.sign, mon.prev_abs_g
+
+    # s == 0, |g| = Inf: a pole by definition.
+    if !isfinite(abs_g)
+        _handle_border_pole!(mon, label, "|g| = Inf (cᵀJ⁻¹b hit d exactly)")
+        return false
+    end
+
+    # No flip: first observation, or unchanged sign.
+    if prev == 0 || current == 0 || current == prev
+        current == 0 || (mon.sign = current)
+        mon.prev_abs_g = abs_g
+        return false
+    end
+
+    # Flipped. Zero (fold) or pole (degenerate bordering)? Bisect the step: as the
+    # bracket tightens onto the event, |g| → 0 at a zero and → ∞ at a pole whatever
+    # det(M) is doing.
+    event = _bracket_fold_flip!(mon, label, bracket, prev_abs, abs_g, prev)
+    if event === :pole
+        _handle_border_pole!(mon, label, _fold_evidence(event))
+        return false
+    end
+    mon.sign = current
+    mon.prev_abs_g = abs_g
+
+    @warn "$label: sign(det J) flipped " *
+          "($(prev > 0 ? "+" : "−") → $(current > 0 ? "+" : "−")); " *
+          "$(_fold_evidence(event)). Fold / voltage-collapse " *
+          "signature$(bail ? ", aborting." : ".")"
+    return bail
+end
+
+"""Phrase the evidence behind a flip verdict."""
+_fold_evidence(event::Symbol) =
+    if event === :zero
+        "bisection drove |g| DOWN — through zero"
+    elseif event === :pole
+        "bisection drove |g| UP"
+    elseif event === :unavailable
+        "no bracketing (unsupported by this solver) — read conservatively as zero"
+    else  # :unresolved
+        "bisection inconclusive — read conservatively as zero"
+    end
+
+"""Classify a sign flip of `g` by bisecting the step that produced it.
+
+`bracket(θ)` re-evaluates `g` at the interpolated iterate
+`x_prev + θ·(x − x_prev)`; the caller is responsible for restoring `residual`/`J`
+afterwards. Bisection keeps the sub-interval that still brackets the sign change, so
+after `FOLD_BRACKET_STEPS` steps both ends sit next to the event. Near a simple
+zero, `|g| ∼ C·|θ − θ*|` shrinks geometrically as the bracket tightens; near a
+simple pole, `|g| ∼ C/|θ − θ*|` grows.
+
+Returns `:zero`, `:pole`, `:unavailable` (no bracket callable, or no previous
+iterate), or `:unresolved` (bisection did not separate the two)."""
+function _bracket_fold_flip!(
+    mon::BorderedFoldMonitor,
+    label::AbstractString,
+    bracket::Union{Function, Nothing},
+    abs_lo::Float64,
+    abs_hi::Float64,
+    sign_lo::Int8,
+)::Symbol
+    (isnothing(bracket) && return :unavailable)
+    mon.has_prev_x || return :unavailable
+
+    θ_lo, θ_hi = 0.0, 1.0
+    a_lo, a_hi = abs_lo, abs_hi
+    for _ in 1:FOLD_BRACKET_STEPS
+        θ_mid = 0.5 * (θ_lo + θ_hi)
+        g_mid = bracket(θ_mid)
+        # An exactly singular J mid-step IS the zero we were looking for; a
+        # non-finite g there is the pole.
+        isnan(g_mid) && return :zero
+        isfinite(g_mid) || return :pole
+        a_mid = abs(g_mid)
+        if Int8(sign(g_mid)) == sign_lo
+            θ_lo, a_lo = θ_mid, a_mid
+        else
+            θ_hi, a_hi = θ_mid, a_mid
+        end
+    end
+
+    outer, inner = min(abs_lo, abs_hi), max(a_lo, a_hi)
+    inner < outer && return :zero
+    min(a_lo, a_hi) > max(abs_lo, abs_hi) && return :pole
+    @debug "$label: bisection did not separate a zero from a pole " *
+           "(flanking |g| ∈ [$(_sf4(min(abs_lo, abs_hi))), $(_sf4(max(abs_lo, abs_hi)))], " *
+           "bracketed |g| ∈ [$(_sf4(min(a_lo, a_hi))), $(_sf4(inner))])"
+    return :unresolved
+end
+
+"""Handle a pole of `g`: `det M` crossed zero, so the bordering — not `J` — went
+singular. Re-pick `(b, c)` and keep going; after `FOLD_MAX_BORDER_REPICKS` failures
+disable the monitor rather than report a fold that was never observed."""
+function _handle_border_pole!(
+    mon::BorderedFoldMonitor,
+    label::AbstractString,
+    detail::AbstractString,
+)
+    if mon.attempt > FOLD_MAX_BORDER_REPICKS
+        mon.enabled = false
+        @warn "$label: bordering degenerated $(mon.attempt)× ($detail); " *
+              "disabling fold detection — solve continues with NO fold bail-out."
+        return
+    end
+    @warn "$label: g passed through a pole ($detail): det(M) crossed zero — " *
+          "degenerate bordering, not a property of J. Re-picking (b, c)."
+    _repick_bordering!(mon)
+    return
+end
 
 """Per-solve scratch for [`run_solver_diagnostics!`](@ref): previous ‖F‖∞ (`prev_F`),
-last-seen sign of `real(λ_min)` (`eig_sign`), and a reusable padded RHS (`buffer`) so
-the Schur operator allocates nothing per iteration."""
+the bordered `sign(det J)` fold monitor (`fold`), and a reusable padded RHS
+(`buffer`) so the Schur operator allocates nothing per iteration."""
 mutable struct SolverDiagnosticsState
     prev_F::Float64
-    eig_sign::EigvalSign
+    fold::BorderedFoldMonitor
     buffer::Vector{Float64}
 end
 
-SolverDiagnosticsState(n_state::Int) =
-    SolverDiagnosticsState(NaN, EigvalSign.UNSEEN, Vector{Float64}(undef, n_state))
+SolverDiagnosticsState(n_state::Int) = SolverDiagnosticsState(
+    NaN, BorderedFoldMonitor(n_state), Vector{Float64}(undef, n_state))
 
 """Set up a solver loop's diagnostics: returns `(monitor, diag_state)`, allocating
 the scratch only when a diagnostic or the bail-out is on so the default solve path
@@ -202,45 +437,19 @@ function setup_solver_diagnostics(
     return monitor, diag_state
 end
 
-"""Update `state.eig_sign` from `λ_min` and decide the fold bail-out. A non-converged
-or non-finite `real(λ_min)` is a conservative bail (warn + abort), never a silent
-no-op. An exact-zero real part keeps the prior sign. Returns `true` to abort."""
-function _decide_eig_sign_switch!(
-    state::SolverDiagnosticsState,
-    label::AbstractString,
-    λ_min::ComplexF64,
-    converged::Bool,
-)::Bool
-    s = real(λ_min)
-    if !converged || !isfinite(s)
-        @warn "$label: λ_min(S) is indeterminate " *
-              "(converged = $converged, λ_min = $(_fmt_eig(λ_min))); treating it as " *
-              "a fold / voltage-collapse signature and aborting the search."
-        return true
-    end
-    prev = state.eig_sign
-    current = s > 0 ? EigvalSign.POSITIVE : (s < 0 ? EigvalSign.NEGATIVE : prev)
-    state.eig_sign = current
-
-    # A switch needs a real, previously-seen sign that differs from the new one.
-    switched = prev != EigvalSign.UNSEEN && current != prev
-    switched || return false
-
-    @warn "$label: λ_min(S) real part switched sign " *
-          "($(prev == EigvalSign.POSITIVE ? "+" : "−") → " *
-          "$(current == EigvalSign.POSITIVE ? "+" : "−")), " *
-          "λ_min = $(_fmt_eig(λ_min)). This is a fold / voltage-collapse " *
-          "signature; aborting the search."
-    return true
-end
-
 """Run one iteration's diagnostics against the current `J`/residual. Does the
 *single* per-iteration refactor of `cache` on `J.Jv` (NR/TR pass `linSolveCache`, LM
-its own KLU `diag_cache`) and, on success, the *single* eigensolve shared by the
-monitor line (`monitor`) and the fold bail-out (`bail`). Returns `true` iff the
-caller should abort. A `SingularException` is itself a fold signature: under `bail`
-it aborts, under monitor-only it reports `singular` and continues; any other
-exception is rethrown."""
+its own KLU `diag_cache`), then the bordered `sign(det J)` monitor (one back-solve)
+and, when the log line is on, the Schur eigensolve behind `λ_min(S)`. Returns `true`
+iff the caller should abort. A `SingularException` is itself a fold signature: under
+`bail` it aborts, under monitor-only it reports `singular` and continues; any other
+exception is rethrown.
+
+Pass `x` (the current iterate) only when `residual` and `J` are both evaluated *at*
+it: that lets an ambiguous sign flip be resolved by bracketing the step, which
+re-evaluates both at interpolated iterates and restores them afterwards. NR/TR
+satisfy this; LM does not (its `J` lags the residual by a step) and passes
+`nothing`."""
 function run_solver_diagnostics!(
     state::SolverDiagnosticsState,
     label::AbstractString,
@@ -250,6 +459,7 @@ function run_solver_diagnostics!(
     cache::PFLinearSolverCache,
     monitor::Bool,
     bail::Bool,
+    x::Union{AbstractVector{Float64}, Nothing} = nothing,
 )::Bool
     # KLU throws `SingularException` on a singular J; AppleAccelerate does not (it
     # silently returns garbage but still factors), so only KLU reaches the catch.
@@ -273,21 +483,27 @@ function run_solver_diagnostics!(
         abs_max, ix = findmax(abs, residual.Rv)
         @info "$label: ‖F‖_∞ = $(_sf4(abs_max)) at " *
               "$(_describe_residual_entry(residual, data, time_step, ix)), " *
-              "κ̂(J) = singular, λ_min(S) = singular"
+              "κ̂(J) = singular, λ_min(S) = singular, sign(det J) = singular"
         return false
     end
 
-    n_state = size(J.Jv, 1)
-    # Trailing block is the FULL non-bus tail (LCC + VSC + area interchange), not just
-    # LCC: n_state on a VSC/area-interchange system is larger than 2*nbuses + 4*n_lcc.
-    n_bus = n_state - state_tail_length(data, get_dc_network(data))
-    op = SchurInverseOperator(cache, n_bus, state.buffer)
-    λ_min, converged = _schur_min_eigenvalue(op)
+    # The bordered monitor is one back-solve, so it runs whenever diagnostics are on;
+    # only `bail` decides whether a fold signature aborts the search.
+    fold = state.fold
+    g = fold.enabled ? _fold_monitor_value!(fold, cache) : NaN
 
     if monitor
+        # Trailing block is the FULL non-bus tail (LCC + VSC + area interchange), not
+        # just LCC: n_state on a VSC/area-interchange system is larger than
+        # 2*nbuses + 4*n_lcc.
+        n_state = size(J.Jv, 1)
+        n_bus = n_state - state_tail_length(data, get_dc_network(data))
+        op = SchurInverseOperator(cache, n_bus, state.buffer)
+        λ_min, eig_converged = _schur_min_eigenvalue(op)
+
         abs_max, ix = findmax(abs, residual.Rv)
         κ = _diag_condest(cache)
-        λ_str = if converged
+        λ_str = if eig_converged
             "$(_fmt_eig(λ_min)) (|λ_min| = $(_sf4(abs(λ_min))))"
         else
             "not-converged"
@@ -297,6 +513,9 @@ function run_solver_diagnostics!(
             "$(_describe_residual_entry(residual, data, time_step, ix))",
             "κ̂(J) = $(isnan(κ) ? "n/a (KLU-only)" : string(_sf4(κ)))",
             "λ_min(S) = $λ_str",
+            # sign(g) = sign(det J)·sign(det M); det M is a fixed constant, so only
+            # FLIPS of this sign are meaningful, not the sign itself.
+            "sign(det J) = $(_fmt_det_sign(g))",
         ]
         if !isnan(state.prev_F) && state.prev_F > 0
             push!(parts, "contraction = $(_sf4(abs_max / state.prev_F))")
@@ -305,11 +524,83 @@ function run_solver_diagnostics!(
         state.prev_F = abs_max
     end
 
-    if bail
-        return _decide_eig_sign_switch!(state, label, λ_min, converged)
+    # Bracketing re-evaluates `residual`/`J` at interpolated iterates, so it is only
+    # offered when the caller vouches that both are at `x`, and it always restores
+    # them (and the factorization) before returning.
+    # `bracketed` keeps the restore off the hot path: bracketing only runs on an
+    # ambiguous sign flip, so the common iteration pays nothing for this.
+    bracketed = Ref(false)
+    bracket = if (isnothing(x) || !fold.has_prev_x)
+        nothing
+    else
+        function (θ::Float64)
+            bracketed[] = true
+            return _fold_value_at_interpolated_iterate!(
+                fold, residual, J, time_step, cache, x, θ)
+        end
     end
-    return false
+    abort = try
+        _decide_det_sign_switch!(fold, label, g, bail, bracket)
+    finally
+        bracketed[] && _restore_iterate!(residual, J, time_step, cache, x)
+    end
+
+    if !isnothing(x)
+        copyto!(fold.prev_x, x)
+        fold.has_prev_x = true
+    end
+    return abort
 end
+
+"""Evaluate the bordered monitor `g` at `x_prev + θ·(x − x_prev)`. Leaves `residual`,
+`J`, and `cache` at that interpolated iterate — [`_restore_iterate!`](@ref) puts them
+back. Returns `NaN` when the interpolated `J` is outright singular, which
+[`_bracket_fold_flip!`](@ref) reads as the zero it was hunting for."""
+function _fold_value_at_interpolated_iterate!(
+    mon::BorderedFoldMonitor,
+    residual::Union{ACPowerFlowResidual, ACRectangularCIResidual, ACMixedCPBResidual},
+    J::Union{ACPowerFlowJacobian, ACRectangularCIJacobian, ACMixedCPBJacobian},
+    time_step::Int,
+    cache::PFLinearSolverCache,
+    x::AbstractVector{Float64},
+    θ::Float64,
+)
+    @. mon.x_work = mon.prev_x + θ * (x - mon.prev_x)
+    residual(mon.x_work, time_step)
+    J(time_step)
+    try
+        numeric_refactor!(cache, J.Jv)
+    catch e
+        e isa LinearAlgebra.SingularException || rethrow()
+        return NaN
+    end
+    return _fold_monitor_value!(mon, cache)
+end
+
+"""Put `residual`, `J`, and `cache`'s factorization back at the iterate `x` after
+bracketing perturbed them. The solver loop reads `residual.Rv` for its convergence
+test immediately after the diagnostics hook, so this is not optional."""
+function _restore_iterate!(
+    residual::Union{ACPowerFlowResidual, ACRectangularCIResidual, ACMixedCPBResidual},
+    J::Union{ACPowerFlowJacobian, ACRectangularCIJacobian, ACMixedCPBJacobian},
+    time_step::Int,
+    cache::PFLinearSolverCache,
+    x::AbstractVector{Float64},
+)
+    residual(x, time_step)
+    J(time_step)
+    try
+        numeric_refactor!(cache, J.Jv)
+    catch e
+        # A singular J at the restored iterate is the caller's problem to report, not
+        # something to raise from inside a diagnostic's cleanup.
+        e isa LinearAlgebra.SingularException || rethrow()
+    end
+    return
+end
+
+"""`+`/`−` for the monitor's sign, or `n/a` when `g` is unavailable."""
+_fmt_det_sign(g::Float64) = isnan(g) ? "n/a" : (g > 0 ? "+" : (g < 0 ? "−" : "0"))
 
 """
     _report_area_interchange_failure(data, time_step)

--- a/test/test_residual_condition_diagnostics.jl
+++ b/test/test_residual_condition_diagnostics.jl
@@ -164,3 +164,233 @@ end
         @test solve_power_flow!(data)
     end
 end
+
+# ---------------------------------------------------------------------------
+# Bordered fold monitor: g = 1/(d − cᵀJ⁻¹b) = det(J)/det(M).
+# ---------------------------------------------------------------------------
+
+# A one-parameter family of Jacobians with a KNOWN singularity, on a single fixed
+# sparsity pattern (so the sweep is a pure numeric refactor, as in a solver loop).
+# det is AFFINE in one diagonal entry, so sweeping A[1,1] crosses zero exactly once
+# and the crossing point is recoverable from two samples.
+function _singular_matrix_family(; backend = PNM.KLUSolver())
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; correct_bustypes = true)
+    data = PF.PowerFlowData(pf, sys)
+    residual = PF.ACPowerFlowResidual(data, 1)
+    jac = PF.ACPowerFlowJacobian(residual, 1)
+    x0 = PF.calculate_x0(data, 1)
+    residual(x0, 1)
+    jac(1)
+
+    n = size(jac.Jv, 1)
+    # An odd shift keeps every diagonal entry structurally stored (a cancelling
+    # sum would be pruned, and the pattern must not change across the sweep).
+    shift = 0.3141592653589793
+    A = jac.Jv + shift * SparseArrays.sparse(LinearAlgebra.I, n, n)
+    dptr = [
+        only(filter(k -> A.rowval[k] == i, A.colptr[i]:(A.colptr[i + 1] - 1)))
+        for i in 1:n
+    ]
+    for i in 1:n
+        A.nzval[dptr[i]] -= shift
+    end
+    diag_11 = A.nzval[dptr[1]]
+    set_t! = t -> (A.nzval[dptr[1]] = diag_11 + t)
+
+    cache = PF.make_linear_solver_cache(backend, A)
+    PF.symbolic_factor!(cache, A)
+    g_at = function (t)
+        set_t!(t)
+        PF.numeric_refactor!(cache, A)
+        return A, cache
+    end
+    set_t!(0.0)
+    d0 = LinearAlgebra.det(Matrix(A))
+    set_t!(1.0)
+    d1 = LinearAlgebra.det(Matrix(A))
+    return (; A, n, cache, set_t!, g_at, t_star = d0 / (d0 - d1))
+end
+
+@testset "bordering vectors are deterministic and normalized" begin
+    # Reproducible logs depend on the bordering being identical run to run.
+    v1, v2, v3 = (Vector{Float64}(undef, 64) for _ in 1:3)
+    PF._fill_border_vector!(v1, UInt64(12345))
+    PF._fill_border_vector!(v2, UInt64(12345))
+    PF._fill_border_vector!(v3, UInt64(12346))
+    @test v1 == v2                       # same seed, same vector
+    @test v1 != v3                       # different seed, different vector
+    @test isapprox(LinearAlgebra.norm(v1), 1.0; atol = 1e-12)
+    @test all(isfinite, v1)
+end
+
+@testset "sign(g) tracks sign(det J) across a singularity" begin
+    fam = _singular_matrix_family()
+    mon = PF.BorderedFoldMonitor(fam.n)
+    # A window tight around the singularity, so the sweep contains the zero and no
+    # pole; the exact crossing itself is skipped (det = 0 there, g = NaN).
+    ts = [
+        t for t in range(fam.t_star - 0.3, fam.t_star + 0.3; length = 21)
+        if abs(t - fam.t_star) > 1e-12
+    ]
+    offsets = Int[]
+    signs_g, signs_d = Int[], Int[]
+    for t in ts
+        _, cache = fam.g_at(t)
+        g = PF._fold_monitor_value!(mon, cache)
+        d = LinearAlgebra.det(Matrix(fam.A))
+        @test isfinite(g)
+        push!(signs_g, Int(sign(g)))
+        push!(signs_d, Int(sign(d)))
+        push!(offsets, Int(sign(g) * sign(d)))
+    end
+    # det J and g each flip signs once in the interval
+    @test count(i -> signs_g[i] != signs_g[i - 1], 2:length(signs_g)) == 1
+    @test count(i -> signs_d[i] != signs_d[i - 1], 2:length(signs_d)) == 1
+    # one flips signs exactly when the other flips signs.
+    @test length(unique(offsets)) == 1
+end
+
+@testset "bisection classifies a genuine zero as a fold" begin
+    fam = _singular_matrix_family()
+    mon = PF.BorderedFoldMonitor(fam.n)
+    mon.has_prev_x = true    # the synthetic bracket below stands in for the iterate
+
+    t_lo, t_hi = fam.t_star - 0.25, fam.t_star + 0.25
+    g_of = t -> PF._fold_monitor_value!(mon, fam.g_at(t)[2])
+    g_lo, g_hi = g_of(t_lo), g_of(t_hi)
+    @test sign(g_lo) != sign(g_hi)       # the interval brackets the singularity
+
+    bracket = θ -> g_of(t_lo + θ * (t_hi - t_lo))
+    event = PF._bracket_fold_flip!(
+        mon, "test", bracket, abs(g_lo), abs(g_hi), Int8(sign(g_lo)))
+    @test event === :zero
+end
+
+@testset "bisection classifies a bordering pole, not a fold" begin
+    # det M = det J · s crosses zero somewhere; there sign(g) flips while det J does
+    # NOT. Locate such a bracket by scanning, then check it is called a pole.
+    fam = _singular_matrix_family()
+    mon = PF.BorderedFoldMonitor(fam.n)
+    mon.has_prev_x = true
+    g_of = t -> PF._fold_monitor_value!(mon, fam.g_at(t)[2])
+
+    ts = collect(range(fam.t_star + 0.05, fam.t_star + 3.0; length = 60))
+    gs = [g_of(t) for t in ts]
+    ds = [(fam.set_t!(t); LinearAlgebra.det(Matrix(fam.A))) for t in ts]
+    k = findfirst(
+        i ->
+            isfinite(gs[i]) && isfinite(gs[i - 1]) &&
+                sign(gs[i]) != sign(gs[i - 1]) &&
+                sign(ds[i]) == sign(ds[i - 1]), 2:length(ts))
+    @test !isnothing(k)                  # this bordering does hit a pole
+    i = k + 1
+    t_lo, t_hi = ts[i - 1], ts[i]
+    bracket = θ -> g_of(t_lo + θ * (t_hi - t_lo))
+    event = PF._bracket_fold_flip!(
+        mon, "test", bracket, abs(gs[i - 1]), abs(gs[i]), Int8(sign(gs[i - 1])))
+    @test event === :pole
+end
+
+@testset "a flip with no bracket is unavailable, not a verdict" begin
+    mon = PF.BorderedFoldMonitor(8)
+    @test PF._bracket_fold_flip!(mon, "test", nothing, 1.0, 1.0, Int8(1)) ===
+          :unavailable
+    # Even with a bracket, an unseen previous iterate cannot define a segment.
+    @test PF._bracket_fold_flip!(mon, "test", θ -> 1.0, 1.0, 1.0, Int8(1)) ===
+          :unavailable
+end
+
+@testset "an unclassifiable flip is read conservatively as a fold" begin
+    # Without a bracket (LM) nothing can be established about the flip, so the
+    # monitor must bail rather than wave it through.
+    mon = PF.BorderedFoldMonitor(8)
+    tl = Test.TestLogger(; min_level = Logging.Warn)
+    bailed = Logging.with_logger(tl) do
+        PF._decide_det_sign_switch!(mon, "t1", 1.0, true)   # first sign, no flip
+        PF._decide_det_sign_switch!(mon, "t2", -1.0, true)  # flip, no bracket
+    end
+    @test bailed
+    msgs = [r.message for r in tl.logs]
+    @test any(m -> occursin("no bracketing", m), msgs)
+    @test any(m -> occursin("read conservatively as zero", m), msgs)
+    # `bail = false` classifies and logs identically but never aborts.
+    mon2 = PF.BorderedFoldMonitor(8)
+    Logging.with_logger(Logging.NullLogger()) do
+        PF._decide_det_sign_switch!(mon2, "t1", 1.0, false)
+        @test !PF._decide_det_sign_switch!(mon2, "t2", -1.0, false)
+    end
+end
+
+@testset "repeated bordering poles disable the monitor rather than cry fold" begin
+    mon = PF.BorderedFoldMonitor(8)
+    b_first = copy(mon.b)
+    @test mon.enabled
+    for _ in 1:(PF.FOLD_MAX_BORDER_REPICKS)
+        Logging.with_logger(Logging.NullLogger()) do
+            PF._handle_border_pole!(mon, "test", "synthetic")
+        end
+    end
+    @test mon.enabled                    # still re-picking
+    @test mon.b != b_first               # with a genuinely different bordering
+    Logging.with_logger(Logging.NullLogger()) do
+        PF._handle_border_pole!(mon, "test", "synthetic")
+    end
+    @test !mon.enabled                   # gives up instead of reporting a fold
+    # A disabled monitor never bails, whatever it is fed.
+    @test !PF._decide_det_sign_switch!(mon, "test", -1.0, true)
+end
+
+@testset "the monitor line reports sign(det J)" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; correct_bustypes = true,
+        log_solver_diagnostics = true, solver_settings = _KLU_SETTINGS)
+    lines = _solver_diagnostic_lines(pf, sys)
+    @test length(lines) >= 2
+    for line in lines
+        @test occursin(r"sign\(det J\) = [+−]", line)
+    end
+end
+
+@testset "stop_at_fold aborts on a stressed system with a det-sign warning" begin
+    # c_sys14 with every load scaled well past the nose: the solve must not report
+    # convergence, and must say WHY in terms of sign(det J).
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; correct_bustypes = true,
+        solver_settings = Dict{Symbol, Any}(
+            :linear_solver => "KLU", :stop_at_fold => true))
+    data = PF.PowerFlowData(pf, sys)
+    data.bus_active_power_withdrawals .*= 6.0
+    data.bus_reactive_power_withdrawals .*= 6.0
+    tl = Test.TestLogger(; min_level = Logging.Warn)
+    converged = Logging.with_logger(tl) do
+        solve_power_flow!(data)
+    end
+    @test !converged
+    msgs = [r.message for r in tl.logs]
+    @test any(m -> occursin("sign(det J) flipped", m), msgs)
+    @test any(m -> occursin("Fold / voltage-collapse signature", m), msgs)
+end
+
+@testset "diagnostics never perturb the solve" begin
+    # Bracketing re-evaluates residual/J at interpolated iterates. If the restore is
+    # exact, the iterates must be bit-identical to a solve with diagnostics off.
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    function final_state(; stop_at_fold, scale, maxiter)
+        pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; correct_bustypes = true,
+            solver_settings = Dict{Symbol, Any}(:linear_solver => "KLU",
+                :stop_at_fold => stop_at_fold, :maxIterations => maxiter))
+        data = PF.PowerFlowData(pf, sys)
+        data.bus_active_power_withdrawals .*= scale
+        data.bus_reactive_power_withdrawals .*= scale
+        Logging.with_logger(Logging.NullLogger()) do
+            solve_power_flow!(data)
+        end
+        return vcat(vec(copy(data.bus_magnitude)), vec(copy(data.bus_angles)))
+    end
+    for scale in (3.0, 6.0, 12.0), maxiter in (2, 7)
+        off = final_state(; stop_at_fold = false, scale, maxiter)
+        on = final_state(; stop_at_fold = true, scale, maxiter)
+        @test isequal(off, on)           # `isequal` so NaN == NaN on aborted solves
+    end
+end


### PR DESCRIPTION
For fold detection, I believe `sign(det(J))` here is the thing to look at, over the sign of the real part of the smallest eigenvalue. This PR achieves that via a bordered matrix strategy, described below by AI:

> Border J with fixed vectors:
> 
> M = [ J   b; cᵀ  d ]
> 
> Schur complement gives det(M) = det(J) · (d − cᵀJ⁻¹b). Define
> 
> s = d − cᵀ J⁻¹ b;  g = 1/s = det(J) / det(M)
> 
> g is smooth in the continuation parameter, and vanishes exactly when J is singular — because det M is a fixed smooth function that is nonzero near a simple fold for generic b, c. So sign(g) differs from sign(det J) only by the constant factor sign(det M), and flips of g are flips of det J.
> 
> Computational cost: one solve J y = b against the existing factorization plus a dot product. 
> 
> g can change sign two ways, and they're distinguishable by magnitude:
> 
> - Through zero (|g| decreases toward 0, then grows): genuine singularity of J. This is your fold.
> - Through a pole (|g| blows up): det M crossed zero — your bordering degenerated, not a property of J. Re-pick b, c and recompute the monitor over the whole interval.

Some light polishing to do--AI comment verbosity, error if feature is requested for non-TR/NR solvers--but I want input on the algorithm