### PR TITLE
test: cover flow reporting for nested reduction aggregates

### DIFF
--- a/test/test_nested_reduction_flow_reporting.jl
+++ b/test/test_nested_reduction_flow_reporting.jl
@@ -1,0 +1,254 @@
+#=
+Flow reporting for reduction aggregates that contain other reduction aggregates.
+
+`DegreeTwoReduction` deliberately builds two nested shapes (PNM `degree_two_reduction.jl`,
+and PNM's own `test_nested_reduction_aggregates.jl`):
+
+  - a parallel group as a chain segment -- `BranchesSeries` holding a `BranchesParallel`
+  - sibling chains in parallel          -- `BranchesParallel{BranchesSeries}`
+
+and the two compose, giving a `BranchesParallel{BranchesSeries}` whose chains themselves
+carry a parallel segment.
+
+PowerFlows expands an aggregate arc back to its physical branches in two places, and both
+descend only into the first shape:
+
+  - AC:  `_compute_segment_flows` (`post_processing.jl`), which special-cases
+    `segment isa AbstractBranchesParallel` inside the `BranchesSeries` method but hands every
+    member of a `AbstractBranchesParallel` straight to `_segment_flow_entry`.
+  - DC/PTDF: `_distribute_arc_flows`, with the same asymmetry.
+
+So a chain nested inside a parallel group is never descended into. Because
+`AbstractReductionAggregate <: PSY.ACTransmission` (PNM `definitions.jl`), the chain is
+accepted by the leaf-branch method signatures rather than rejected at the PowerFlows
+boundary, and the failure surfaces deep in PSY as `get_r(::BranchesSeries, ::SystemBaseUnit)`
+(AC) or as the `result.count == n_branches` assertion (DC/PTDF).
+
+The first shape is covered here as a passing test; the other two are `@test_broken`. Real
+datasets rarely nest this far -- ACTIVSg2000 under `DegreeTwoReduction` has 410 parallel
+groups, none of them parallel-of-chains, and 7 chains with a parallel segment -- so this is
+documented rather than fixed.
+=#
+
+# Minimal systems that produce one nested aggregate each. Buses 1 and 2 carry injections, so
+# they are irreducible endpoints; buses 3 and 4 are bare and become chain interiors.
+function _nested_reduction_system(shape::Symbol)
+    sys = PSY.System(100.0)
+    buses = Dict{Int, PSY.ACBus}()
+    function add_bus!(number, bustype)
+        b = PSY.ACBus(;
+            number = number,
+            name = "b$number",
+            available = true,
+            bustype = bustype,
+            angle = 0.0,
+            magnitude = 1.0,
+            voltage_limits = (min = 0.9, max = 1.1),
+            base_voltage = 230.0,
+        )
+        PSY.add_component!(sys, b)
+        buses[number] = b
+        return b
+    end
+    function add_line!(name, from, to, r, x)
+        arc_name = "$(PSY.get_name(buses[from])) -> $(PSY.get_name(buses[to]))"
+        arc = PSY.get_component(PSY.Arc, sys, arc_name)
+        if isnothing(arc)
+            arc = PSY.Arc(; from = buses[from], to = buses[to])
+            PSY.add_component!(sys, arc)
+        end
+        PSY.add_component!(
+            sys,
+            PSY.Line(;
+                name = name,
+                available = true,
+                active_power_flow = 0.0,
+                reactive_power_flow = 0.0,
+                arc = arc,
+                r = r,
+                x = x,
+                b = (from = 0.0, to = 0.0),
+                rating = 4.0,
+                angle_limits = (min = -pi, max = pi),
+            ),
+        )
+    end
+
+    add_bus!(1, PSY.ACBusTypes.REF)
+    add_bus!(2, PSY.ACBusTypes.PQ)
+    add_bus!(3, PSY.ACBusTypes.PQ)
+    shape != :parallel_in_series && add_bus!(4, PSY.ACBusTypes.PQ)
+
+    # Chain 1-3-2, whose 1-3 segment is a parallel pair.
+    if shape in (:parallel_in_series, :nested)
+        add_line!("L13a", 1, 3, 0.01, 0.10)
+        add_line!("L13b", 1, 3, 0.02, 0.20)
+    else
+        add_line!("L13", 1, 3, 0.01, 0.10)
+    end
+    add_line!("L32", 3, 2, 0.01, 0.12)
+    # Chain 1-4-2, a sibling of chain 1-3-2 on the same endpoint pair.
+    if shape != :parallel_in_series
+        add_line!("L14", 1, 4, 0.015, 0.15)
+        add_line!("L42", 4, 2, 0.015, 0.14)
+    end
+
+    PSY.add_component!(
+        sys,
+        PSY.PowerLoad(;
+            name = "load2",
+            available = true,
+            bus = buses[2],
+            active_power = 1.0,
+            reactive_power = 0.2,
+            base_power = 100.0,
+            max_active_power = 1.0,
+            max_reactive_power = 0.2,
+        ),
+    )
+    PSY.add_component!(
+        sys,
+        PSY.ThermalStandard(;
+            name = "gen1",
+            available = true,
+            status = true,
+            bus = buses[1],
+            active_power = 1.05,
+            reactive_power = 0.25,
+            rating = 5.0,
+            active_power_limits = (min = 0.0, max = 5.0),
+            reactive_power_limits = (min = -5.0, max = 5.0),
+            ramp_limits = nothing,
+            operation_cost = PSY.ThermalGenerationCost(nothing),
+            base_power = 100.0,
+            time_limits = nothing,
+            prime_mover_type = PSY.PrimeMovers.OT,
+            fuel = PSY.ThermalFuels.OTHER,
+        ),
+    )
+    return sys
+end
+
+_degree_two() = PNM.NetworkReduction[PNM.DegreeTwoReduction(;
+    reduce_reactive_power_injectors = false,
+)]
+
+function _nested_reduction_data(sys)
+    return PNM.get_network_reduction_data(
+        PNM.Ybus(sys; network_reductions = _degree_two()),
+    )
+end
+
+"""Run `f` and report `:ok` or the exception, so a currently-throwing reporting path can be
+pinned with `@test_broken` without the throw escaping the testset."""
+function _reporting_outcome(f)
+    try
+        f()
+        return :ok
+    catch e
+        return e
+    end
+end
+
+_ac_pf(; kwargs...) = PF.ACPowerFlow(; network_reductions = _degree_two(), kwargs...)
+
+@testset "nested aggregates: parallel group inside a chain" begin
+    sys = _nested_reduction_system(:parallel_in_series)
+    nrd = _nested_reduction_data(sys)
+
+    # Pin the fixture: one chain on arc (1, 2), whose first segment is a parallel group.
+    @test isempty(PNM.get_parallel_branch_map(nrd))
+    chain = only(values(PNM.get_series_branch_map(nrd)))
+    @test chain isa PNM.BranchesSeries
+    @test count(s -> s isa PNM.AbstractBranchesParallel, chain) == 1
+
+    # Every physical branch is reported, and reported flows match an unreduced solve.
+    branch_flows(pf) = solve_power_flow(pf, sys, PF.FlowReporting.BRANCH_FLOWS)
+    reduced = branch_flows(_ac_pf())["flow_results"]
+    full = branch_flows(PF.ACPowerFlow())["flow_results"]
+    @test Set(reduced.flow_name) == Set(["L13a", "L13b", "L32"])
+    joined = DataFrames.innerjoin(reduced, full; on = :flow_name, makeunique = true)
+    @test size(joined, 1) == 3
+    for row in eachrow(joined)
+        @test isapprox(row.P_from_to, row.P_from_to_1; atol = 1e-3)
+        @test isapprox(row.Q_from_to, row.Q_from_to_1; atol = 1e-3)
+    end
+
+    # The DC expanders descend into this shape too.
+    for pf in (
+        PF.DCPowerFlow(; network_reductions = _degree_two()),
+        PF.PTDFDCPowerFlow(; network_reductions = _degree_two()),
+    )
+        df = solve_power_flow(pf, sys, PF.FlowReporting.BRANCH_FLOWS)["1"]["flow_results"]
+        @test Set(df.flow_name) == Set(["L13a", "L13b", "L32"])
+    end
+
+    # The chain's interior bus voltage is recovered on write-back.
+    sys2 = _nested_reduction_system(:parallel_in_series)
+    solve_and_store_power_flow!(_ac_pf(), sys2)
+    b3 = PSY.get_component(PSY.ACBus, sys2, "b3")
+    full_b3 = filter(
+        row -> row.bus_number == 3,
+        solve_power_flow(PF.ACPowerFlow(), sys2)["bus_results"],
+    )
+    @test isapprox(PSY.get_magnitude(b3), full_b3[1, :Vm]; atol = 1e-6)
+    @test isapprox(PSY.get_angle(b3), full_b3[1, :θ]; atol = 1e-6)
+end
+
+# Both remaining shapes fail the same way and for the same reason: the expanders treat every
+# member of a parallel group as a physical branch, so a `BranchesSeries` member is never
+# descended into. `:series_in_parallel` shows the defect needs only two levels of nesting;
+# `:nested` is the three-level case.
+_NESTED_PARALLEL_SHAPES = (:series_in_parallel, :nested)
+
+@testset "nested aggregates: chains inside a parallel group ($shape)" for shape in
+                                                                          _NESTED_PARALLEL_SHAPES
+    sys = _nested_reduction_system(shape)
+    nrd = _nested_reduction_data(sys)
+
+    # Pin the fixture: one parallel group on arc (1, 2) whose members are chains.
+    @test isempty(PNM.get_series_branch_map(nrd))
+    group = only(values(PNM.get_parallel_branch_map(nrd)))
+    @test group isa PNM.BranchesParallel{PNM.BranchesSeries}
+    @test all(m isa PNM.BranchesSeries for m in group)
+    # In the three-level case one of those chains also carries a parallel segment.
+    @test any(any(s -> s isa PNM.AbstractBranchesParallel, m) for m in group) ==
+          (shape == :nested)
+
+    expected_names = if shape == :nested
+        Set(["L13a", "L13b", "L32", "L14", "L42"])
+    else
+        Set(["L13", "L32", "L14", "L42"])
+    end
+
+    # AC: `_segment_flow_entry` receives a `BranchesSeries` and asks it for `r`.
+    ac_outcome = _reporting_outcome(
+        () -> solve_power_flow(_ac_pf(), sys, PF.FlowReporting.BRANCH_FLOWS),
+    )
+    @test_broken ac_outcome === :ok
+    @test_broken Set(ac_outcome["flow_results"].flow_name) == expected_names
+
+    # DC/PTDF: `_distribute_arc_flows` emits one row per chain, tripping the branch count.
+    for pf in (
+        PF.DCPowerFlow(; network_reductions = _degree_two()),
+        PF.PTDFDCPowerFlow(; network_reductions = _degree_two()),
+    )
+        dc_outcome = _reporting_outcome(
+            () -> solve_power_flow(pf, sys, PF.FlowReporting.BRANCH_FLOWS),
+        )
+        @test_broken dc_outcome === :ok
+    end
+
+    # Write-back fails the same way, and the chains' interior buses are never reached:
+    # `write_power_flow_solution!` recovers interior voltages by walking the series branch
+    # map, which is empty here because both chains live in the parallel map.
+    sys2 = _nested_reduction_system(shape)
+    store_outcome = _reporting_outcome(() -> solve_and_store_power_flow!(_ac_pf(), sys2))
+    @test_broken store_outcome === :ok
+
+    # Arc-level reporting does not throw, but silently reports only the equivalent arc: the
+    # whole nest collapses to a single 1-2 row rather than the physical branches.
+    arc_df = solve_power_flow(_ac_pf(), sys)["flow_results"]
+    @test size(arc_df, 1) == 1
+    @test arc_df[1, :bus_from] == 1 && arc_df[1, :bus_to] == 2
+end


### PR DESCRIPTION
## What

Adds `test/test_nested_reduction_flow_reporting.jl`, covering branch-flow reporting for reduction aggregates that contain other reduction aggregates. One shape works and is now pinned; two are `@test_broken`.

## Background

`DegreeTwoReduction` deliberately builds two nesting shapes (PNM `degree_two_reduction.jl`, and PNM's own `test_nested_reduction_aggregates.jl`), and they compose:

| shape | container | member | reporting |
|---|---|---|---|
| parallel group as a chain segment | `BranchesSeries` | `BranchesParallel` | ✅ works |
| sibling chains in parallel | `BranchesParallel{BranchesSeries}` | `BranchesSeries` | ❌ broken |

In the places where PF expands the aggregate arc back to its physical branches (`_compute_segment_flows`, `_distribute_arc_flows`), we hand every member of a parallel group straight to the leaf-branch routine, so a chain nested inside a parallel group is never descended into. PNM itself *is* fully recursive here (`_subset_two_port`), so this is a PowerFlows-side gap.

Aside: because `AbstractReductionAggregate <: PSY.ACTransmission`, the chain satisfies those leaf signatures. So the failure lands deep in PSY, instead of getting a clean error in PF.

## What the tests do

Three minimal 3–4 bus fixtures, one per shape (buses 1 and 2 carry injections so they are irreducible endpoints; buses 3 and 4 are bare chain interiors).

- **Working shape** — passing tests: every physical branch appears in `BRANCH_FLOWS`, flows match an unreduced solve, and the chain's interior bus voltage is recovered on write-back. Covers the DC and PTDF paths too, which the existing coverage in `test_post_processing.jl` does not exercise.
- **Broken shapes** — `@test_broken` on the AC, DC, PTDF and write-back paths, plus a plain `@test` documenting that arc-level reporting collapses the nest to one row.

Each testset pins its fixture's aggregate shape with plain `@test`s, so if PNM's grouping changes the fixture stops silently testing the wrong thing.

## Why documented rather than fixed

Real datasets rarely nest this far. Under `DegreeTwoReduction`, ACTIVSg2000 has 410 parallel groups, **none** of them parallel-of-chains, and 7 chains with a parallel segment; `case10_radial_series_reductions` has 2 chains with a parallel segment and no parallel groups. The existing suite therefore cannot structurally reach the broken path.

The area already carries a standing caveat at `PowerFlowData.jl:569`: *"Degree 2 network reductions mis-report branch power flows, but bus voltage results are correct."*

## Test plan

```
julia --project=test -e 'using PowerFlows; include("test/PowerFlowsTests.jl"); using .PowerFlowsTests, ReTest; retest(PowerFlowsTests, r"nested aggregates")'
```

Result: **27 passed, 10 broken, 0 failed, 0 errored.** Formatter run; no other files touched.

## Adjacent, not addressed here

`_compute_segment_flows`'s `BranchesSeries` method assumes every member of a nested parallel segment shares the group's arc orientation, but `_build_chain_merge_group` exists precisely to hold anti-parallel members on a chain segment. An anti-frame member would get its endpoint voltages swapped. Not reproduced, so not tested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmjCvHjD7AfJcF5yccAndf