### PR TITLE
fix: pin the remaining unregistered OpenAPI packages in the root and docs envs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,9 @@ InfrastructureTimeSeriesOpenAPIModels = "37a216c8-a490-47cf-89d7-db2cb9618199"
 InfrastructureCoreOpenAPIModels = "1f5e1c8d-e0cc-4dbf-8c6d-f2a3d2ae70a8"
 PowerNetworkMatrices = "bed98974-b02a-5e2f-9fe0-a103f5c450dd"
 PowerOperationsOpenAPIModels = "a372b6d7-45a2-44c2-8199-6a724b72e8ff"
+PowerDynamicsOpenAPIModels = "044a0b22-31f8-4ef6-8282-c9a61b3013f6"
+PowerInvestmentsOpenAPIModels = "33cb4396-f4d9-4f59-8585-787ebb56cb1b"
+PowerOpenAPIModels = "0730f07c-cff6-4c3b-a9df-c546153be50a"
 PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -43,6 +46,9 @@ PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPI
 InfrastructureTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "InfrastructureTimeSeriesOpenAPIModels.jl"}
 InfrastructureCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "InfrastructureCoreOpenAPIModels.jl"}
 PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
+PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl"}
+PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl"}
+PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOpenAPIModels.jl"}
 
 [compat]
 DataFrames = "1"
@@ -60,6 +66,9 @@ InfrastructureTimeSeriesOpenAPIModels = "0.1"
 InfrastructureCoreOpenAPIModels = "0.1"
 PowerNetworkMatrices = "^0.24"
 PowerOperationsOpenAPIModels = "0.1"
+PowerDynamicsOpenAPIModels = "0.1"
+PowerInvestmentsOpenAPIModels = "0.1"
+PowerOpenAPIModels = "0.1"
 PowerSystems = "^5.10"
 SparseArrays = "1"
 StaticArrays = "^1.9"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,12 @@
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+InfrastructureCoreOpenAPIModels = "1f5e1c8d-e0cc-4dbf-8c6d-f2a3d2ae70a8"
+InfrastructureTimeSeriesOpenAPIModels = "37a216c8-a490-47cf-89d7-db2cb9618199"
+PowerCoreOpenAPIModels = "b7b40286-e793-417d-a9a0-b1583e4da1cb"
+PowerDynamicsOpenAPIModels = "044a0b22-31f8-4ef6-8282-c9a61b3013f6"
+PowerInvestmentsOpenAPIModels = "33cb4396-f4d9-4f59-8585-787ebb56cb1b"
+PowerOpenAPIModels = "0730f07c-cff6-4c3b-a9df-c546153be50a"
+PowerOperationsOpenAPIModels = "a372b6d7-45a2-44c2-8199-6a724b72e8ff"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -8,10 +15,12 @@ DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 InfrastructureSystems = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+PowerFlowFileParser = "bed98974-b02e-5e2f-9ee0-a103f5c450dd"
 PowerFlows = "94fada2c-fd9a-4e89-8d82-81405f5cb4f6"
 PowerNetworkMatrices = "bed98974-b02a-5e2f-9fe0-a103f5c450dd"
 PowerSystemCaseBuilder = "f00506e0-b84f-492a-93c2-c0a9afc4364e"
 PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
+PowerTableDataParser = "2b750c0e-0bff-11f1-9200-1befd75df6be"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 
 # Mirrors the pins in the root and `test/` environments. Only the ACTIVE project's
@@ -25,6 +34,17 @@ InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/
 PowerNetworkMatrices = {url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl.git", rev = "psy6"}
 PowerSystemCaseBuilder = {url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl.git", rev = "psy6"}
 PowerSystems = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystems.jl.git"}
+# PSCB's own [sources] pin for this is ignored once PSCB is a dependency rather than the root
+# project; the docs env needs its own pin so Pkg can resolve PSCB's unregistered parser dep.
+PowerTableDataParser = {url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl.git", rev = "psy6"}
+PowerFlowFileParser = {url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl.git", rev = "psy6"}
+InfrastructureCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "InfrastructureCoreOpenAPIModels.jl"}
+InfrastructureTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "InfrastructureTimeSeriesOpenAPIModels.jl"}
+PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
+PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl"}
+PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl"}
+PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOpenAPIModels.jl"}
+PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
 
 [compat]
 Documenter = "^1.0"


### PR DESCRIPTION
## Problem

CI is red on every PR into `psy6`. `PowerSystems` and `PowerSystemCaseBuilder` on `psy6` each depend on **seven** unregistered OpenAPI packages, and only the *active* project's `[sources]` are honored — so every environment has to repeat all seven. cdf02bc did that for `test/`, but the root project got four of the seven and `docs/` got none:

| env | pinned | missing |
|---|---|---|
| `test/Project.toml` | 7 | — |
| `Project.toml` (root) | 4 | `PowerDynamicsOpenAPIModels`, `PowerInvestmentsOpenAPIModels`, `PowerOpenAPIModels` |
| `docs/Project.toml` | 0 | all 7, plus `PowerTableDataParser`, `PowerFlowFileParser` |

Both short environments fail to resolve:

```
Unsatisfiable requirements detected for package PowerDynamicsOpenAPIModels [044a0b22]:
 └─restricted to versions 0.1 by PowerSystems — no versions left
```

That accounts for two of the three failing jobs:

- **Julia 1 – ubuntu / macOS / windows** — `julia-buildpkg` resolves the **root** project → the error above, `restricted by PowerSystems`.
- **build (Documentation)** — `Pkg.develop` in `docs/` → the same error, `restricted by PowerSystemCaseBuilder`.

`psy6` has had no CI run since cdf02bc (last run was 2026-07-27 on f28c326), so this surfaced on the next PR rather than on the commit that introduced it.

## Changes

- **Root `Project.toml`**: adds `PowerDynamicsOpenAPIModels`, `PowerInvestmentsOpenAPIModels`, `PowerOpenAPIModels` to `[deps]`, `[sources]` and `[compat]`, alongside the four already pinned.
- **`docs/Project.toml`**: adds all seven, plus the `PowerTableDataParser` and `PowerFlowFileParser` `psy6` pins that `test/` already carries. Those two are needed for the same reason — PSCB's own `[sources]` are ignored once it is a dependency rather than the root — and they surface only after resolution gets far enough to precompile, as `UndefVarError: OpenAPISystem not defined in PowerTableDataParser`.

`test/Project.toml` is already correct and is untouched.

## Verification

From a clean checkout of `psy6` with no manifests present:

- root, `docs/` and `test/` each `Pkg.instantiate()` and `Pkg.update()` without error; `using PowerFlows` loads from the working tree.
- `Pkg.update()` resolves current upstream tips — PowerSystems 5.10.0 `#psy6`, InfrastructureSystems 3.6.0 `#IS4`, PowerNetworkMatrices 0.24.4 `#psy6`, all seven OpenAPI packages `#main`.
- Reverting just the root change reproduces the exact CI error against those same tips, so the pins are load-bearing rather than a stale-cache artifact.

## Not addressed

The **comparison** (Performance Comparison) job fails separately with ``ERROR: `path` and `url` are conflicting specifications``. It was already failing on `psy6` before the OpenAPI split and is untouched here.

I have not verified that `docs/make.jl` *builds* — only that the docs environment resolves. Documentation was failing on `psy6` in July for unrelated reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmjCvHjD7AfJcF5yccAndf