### PR TITLE
feat: update calculation of reactive power losses on line components

### DIFF
--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -477,7 +477,9 @@ end
     _segment_flow_entry(segment, V_from, V_to)
 
 Compute a `BranchFlowEntry` for a single segment given its endpoint voltages. Returns the
-from-to and to-from complex power flows, plus losses.
+from-to and to-from complex power flows, plus losses. For non-line segments, the
+reactive loss is the sum of the terminal reactive powers from the complete branch
+admittance model.
 """
 function _segment_flow_entry(
     segment::PSY.ACTransmission,
@@ -498,6 +500,38 @@ function _segment_flow_entry(
         imag(S_ft),
         imag(S_tf),
         imag(S_ft) + imag(S_tf),
+    ))
+end
+
+"""
+    _segment_flow_entry(segment::PSY.Line, V_from, V_to)
+
+Compute a `BranchFlowEntry` for a transmission line using its endpoint voltages.
+Terminal active and reactive powers use the complete line admittance model. Active
+losses and reactive losses are reported from the series element, excluding line
+charging and line-connected shunt contributions.
+"""
+function _segment_flow_entry(
+    segment::PSY.Line,
+    V_from::ComplexF64,
+    V_to::ComplexF64,
+)
+    (y11, y12, y21, y22) = PNM.ybus_branch_entries(segment)
+    S_ft = V_from * conj(y11 * V_from + y12 * V_to)
+    S_tf = V_to * conj(y21 * V_from + y22 * V_to)
+    S_ft_series = V_from * conj(y12 * (V_to - V_from))
+    S_tf_series = V_to * conj(y21 * (V_from - V_to))
+    arc_tuple = PNM.get_arc_tuple(segment)
+    return BranchFlowEntry((
+        PNM.get_name(segment),
+        arc_tuple[1],
+        arc_tuple[2],
+        real(S_ft),
+        real(S_tf),
+        real(S_ft) + real(S_tf),
+        imag(S_ft),
+        imag(S_tf),
+        imag(S_ft_series) + imag(S_tf_series),
     ))
 end
 


### PR DESCRIPTION
This PR update is based on the Qloss calculation description on PSSE's POM:

> Line losses are calculated as I^2.R and I^2.X, excluding line charging, line connected shunt, and transformer magnetizing admittance components.

Based on this, what we used to have on Qloss calculation was including the net reactive contribution of the shunt and charging elements.

Resulting in
<img width="370" height="279" alt="image" src="https://github.com/user-attachments/assets/b80d94d0-a7c1-470f-b7b2-b5cc5eddb96f" />

With the change, we calculate the power associated with the series branch separately, so that we only use it's contribution on the Qloss, excluding line charging and line-connected shunts.

Resulting in 
<img width="357" height="265" alt="image" src="https://github.com/user-attachments/assets/d422fb62-ec65-44d8-b3c6-1d55a229802a" />

This is based on the LL EI pf case currently being tested.